### PR TITLE
Created Pinned GCHandle structures in FX PInvoke

### DIFF
--- a/src/Shared/Bass/PInvoke/FX.cs
+++ b/src/Shared/Bass/PInvoke/FX.cs
@@ -38,7 +38,7 @@ namespace ManagedBass
         /// <seealso cref="FXGetParameters(int,IntPtr)"/>
         public static bool FXSetParameters(int Handle, IEffectParameter Parameters)
         {
-            var gch = GCHandle.Alloc(Parameters);
+            var gch = GCHandle.Alloc(Parameters, GCHandleType.Pinned);
 
             var result = FXSetParameters(Handle, gch.AddrOfPinnedObject());
 
@@ -76,7 +76,7 @@ namespace ManagedBass
         /// <seealso cref="FXSetParameters(int,IntPtr)"/>
         public static bool FXGetParameters(int Handle, IEffectParameter Parameters)
         {
-            var gch = GCHandle.Alloc(Parameters);
+            var gch = GCHandle.Alloc(Parameters, GCHandleType.Pinned);
 
             var result = FXGetParameters(Handle, gch.AddrOfPinnedObject());
 


### PR DESCRIPTION
Owned structures allocated with GCHandle must be pinned when passing their IntPtr to unmanaged code, to prevent the garbage collector from moving the object. See the Pinned member of https://msdn.microsoft.com/en-us/library/83y4ak54(v=vs.110).aspx.